### PR TITLE
Improve traefik's security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
         ports:
             - "${PUBLIC_PORT}:${PUBLIC_PORT}"
         read_only: true
+        cap_drop:
+          - ALL
+        cap_add:
+          - NET_BIND_SERVICE
         volumes:
             - "./letsencrypt:/letsencrypt"
             - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
         ports:
             - "${PUBLIC_PORT}:${PUBLIC_PORT}"
         read_only: true
+        user: "${DOCKER_UID}:${DOCKER_GID}"
         cap_drop:
           - ALL
         cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
           - ALL
         cap_add:
           - NET_BIND_SERVICE
+        security_opt:
+          - "no-new-privileges:true"
         volumes:
             - "./letsencrypt:/letsencrypt"
             - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
             - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
         ports:
             - "${PUBLIC_PORT}:${PUBLIC_PORT}"
+        read_only: true
         volumes:
             - "./letsencrypt:/letsencrypt"
             - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
This pull request improves the security of the `traefik` docker-compose service by modifying it in the following ways:

- Make the service's file system read-only.
    - Writing possible only to volumes with the write permission.
- Set only the `NET_BIND_SERVICE` Linux kernel capability.
    - It allows binding to ports `< 1024`.
    - It is not needed since Docker 20.03, but it's useful for compatibility and other runtimes.
- Prevent escalating privileges by setting the `no-new-privileges` security option.